### PR TITLE
Custom errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ presign(presign_url)
   .catch((err) => {
     // check is the error was with our upload process
     const {name} = err
-    if (name === 'presignRequest' || name === 'uploadRequest' || name = 'responseStatus') {
+    if (name === 'presignRequest' || name === 'uploadRequest' || name === 'responseStatus') {
       doSomethingWithErrorMessage(err)
     } else {
       // otherwise throw the error

--- a/README.md
+++ b/README.md
@@ -66,6 +66,47 @@ On success, this request will return:
 * `geometry`
 * `bytes`
 
+### Errors
+
+Both `presign` the `upload` methods will return a custom error objects if either `promise` is rejected.
+
+The XHR requests for each method will return a custom `responseStatus` error message if the response status is not between `200` and `300`.
+
+This allows us to check for specific errors in our upload process.
+
+The custom error objects look like this:
+
+```js
+{
+  error: {original error object},
+  message: 'No Authorised'
+  name: 'uploadRequest'
+}
+```
+
+### Example
+```js
+import {upload, presign} from 'attache-upload'
+
+presign(presign_url)
+  .then((presignResponse) => {
+    return upload(presignResponse, fileObject)
+  })
+  .then((uploadResponse) => {
+    return doSomethingWithResponse(uploadResponse)
+  })
+  .catch((err) => {
+    // check is the error was with our upload process
+    const {name} = err
+    if (name === 'presignRequest' || name === 'uploadRequest' || name = 'responseStatus') {
+      doSomethingWithErrorMessage(err)
+    } else {
+      // otherwise throw the error
+      throw err
+    }
+  })
+```
+
 [npm-image]: https://img.shields.io/npm/v/attache-upload.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/attache-upload
 [travis-image]: https://img.shields.io/travis/icelab/attache-upload.js.svg?style=flat-square

--- a/lib/index.js
+++ b/lib/index.js
@@ -126,7 +126,6 @@ function uploadRequest(res, fileObject, showProgress) {
   var file = fileObject.file;
   var uid = fileObject.uid;
 
-
   var uploadURL = buildUploadURL(url, uuid, expiration, hmac, file.name);
 
   return new Promise(function (resolve, reject) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,21 +49,37 @@ _bus2.default.on('abortUploadRequest', function (uid) {
 });
 
 /**
- * checkStatus
- * take a response and check it's `status` property
- * if between 200-300 return the response object
- * else throw an error
- * @param  {[type]} res [description]
- * @return {[type]}     [description]
+ * customError
+ * return an object forming a custom error message
+ * @param  {String} name
+ * @param  {Object} error
+ * @return {Object}
  */
 
-function checkStatus(res) {
+function customError(name, error) {
+  return {
+    error: error,
+    message: error.message,
+    name: name
+  };
+}
+
+/**
+ * responseStatus
+ * take a response and check it's `status` property
+ * if between 200-300 return the response object
+ * else throw a custom error
+ * @param  {Object} res
+ * @return {Object}
+ */
+
+function responseStatus(res) {
   if (res.status >= 200 && res.status < 300) {
     return res;
   } else {
     var error = new Error(res.statusText);
     error.response = res;
-    throw error;
+    throw customError('responseStatus', error);
   }
 }
 
@@ -86,7 +102,7 @@ function parseJSON(res, url) {
  * @param  {String} expiration
  * @param  {String} hmac
  * @param  {String} filename
- * @return {[String}
+ * @return {String}
  */
 
 function buildUploadURL(url, uuid, expiration, hmac, filename) {
@@ -110,6 +126,7 @@ function uploadRequest(res, fileObject, showProgress) {
   var file = fileObject.file;
   var uid = fileObject.uid;
 
+
   var uploadURL = buildUploadURL(url, uuid, expiration, hmac, file.name);
 
   return new Promise(function (resolve, reject) {
@@ -120,7 +137,9 @@ function uploadRequest(res, fileObject, showProgress) {
       showProgress(e, file);
     }).end(function (err, res) {
       delete reqs[uid];
-      if (err) reject(err);
+
+      // throw a custom error message
+      if (err) return reject(customError('uploadRequest', err));
 
       // append the `uploadURL` to the response
       var response = Object.assign({}, res);
@@ -148,7 +167,7 @@ function upload(res, file) {
   var fn = arguments.length <= 3 || arguments[3] === undefined ? uploadRequest : arguments[3];
 
   return new Promise(function (resolve, reject) {
-    fn(res, file, showProgress).then(checkStatus).then(parseJSON).then(function (res) {
+    fn(res, file, showProgress).then(responseStatus).then(parseJSON).then(function (res) {
       resolve(res);
     }).catch(function (err) {
       reject(err);
@@ -171,7 +190,8 @@ function presignRequest(presignUrl, token) {
       'Content-Type': 'application/json',
       'X-CSRF-Token': token
     }).end(function (err, res) {
-      if (err) reject(err);
+      // throw a custom error message
+      if (err) return reject(customError('presignRequest', err));
       resolve(res);
     });
   });
@@ -191,7 +211,7 @@ function presign(presignUrl, token) {
   var fn = arguments.length <= 2 || arguments[2] === undefined ? presignRequest : arguments[2];
 
   return new Promise(function (resolve, reject) {
-    fn(presignUrl, token).then(checkStatus).then(parseJSON).then(function (res) {
+    fn(presignUrl, token).then(responseStatus).then(parseJSON).then(function (res) {
       resolve(res);
     }).catch(function (err) {
       reject(err);

--- a/src/index.js
+++ b/src/index.js
@@ -109,7 +109,6 @@ function buildUploadURL (url, uuid, expiration, hmac, filename) {
 function uploadRequest (res, fileObject, showProgress) {
   const { url, expiration, hmac, uuid } = res
   const { file, uid } = fileObject
-
   const uploadURL = buildUploadURL(url, uuid, expiration, hmac, file.name)
 
   return new Promise((resolve, reject) => {
@@ -215,5 +214,6 @@ function presign (presignUrl, token, fn = presignRequest) {
 
 export {
   presign,
-  upload
+  upload,
+  customError
 }

--- a/test.js
+++ b/test.js
@@ -24,6 +24,10 @@ const file = {
   type: 'image/jpeg'
 }
 
+/**
+ * presign
+ */
+
 test('presign:', (nest) => {
   nest.test('...returns a promise', (t) => {
     return presign(url, token, fakeXHRResponse)
@@ -60,6 +64,10 @@ test('presign:', (nest) => {
     return t.shouldFail(presign(url, token, fakeXHRResponse))
   })
 })
+
+/**
+ * Upload
+ */
 
 test('upload:', (nest) => {
   const presignResponse = {


### PR DESCRIPTION
Hello @makenosound @timriley.

This PR includes custom error messages to be returned if the `presign` or `upload` promises are rejected ( say if certain credentials aren't authorised ) or if the XHR fails by returning a status that is not between `200` or `300`.

So now when we check for errors, we can check for the name of the error and then decide what to do with it - otherwise if another error has been caught we let it bubble up by throwing it.

``` js
presign(presign_url)
  .then((presignResponse) => {
    return upload(presignResponse, fileObject)
  })
  .then((uploadResponse) => {
    return doSomethingWithResponse(uploadResponse)
  })
  .catch((err) => {
    // check is the error was with our upload process
    const {name} = err
    if (name === 'presignRequest' || name === 'uploadRequest' || name === 'responseStatus') {
      doSomethingWithErrorMessage(err)
    } else {
      // otherwise throw the error
      throw err
    }
  })
```
