### PR TITLE
Do not mutate attache response by adding upload url

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ presign(presign_url)
   .then((presignResponse) => {
 
     // presignResponse:
+    //
     // {
-    //   url: "http://path_to_your_attache_serve/upload",
+    //   url: "http://path_to_your_attache_server/upload",
     //   uuid: "5f0d4d62-e082-4cdf-a143-26258de59c47",
     //   expiration: 1461649282,
     //   hmac: "fd89637821afca1787dfe458be29bc87f0366122"
@@ -25,20 +26,14 @@ presign(presign_url)
   })
   .then((uploadResponse) => {
 
-    // Do something with the 'uploadResponse' array.
+    // uploadResponse:
     //
-    // uploadResponse[0] = the attache server response
-    // uploadResponse[1] = the url the file was uploaded to.
-    //
-    // [
-    //   {
-    //     path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
-    //     content_type: "image/jpeg",
-    //     geometry: "300x300",
-    //     bytes: 19804
-    //   },
-    //   "http://path_to_your_attache_serve/upload"
-    // ]
+    // {
+    //   path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
+    //   content_type: "image/jpeg",
+    //   geometry: "300x300",
+    //   bytes: 19804
+    // }
 
   })
   .catch((err) => {
@@ -70,7 +65,7 @@ On success, this request will return:
 presign(presign_url, token)
   .then((presignResponse) => {
     // {
-    //   url: "http://path_to_your_attache_serve/upload",
+    //   url: "http://path_to_your_attache_server/upload",
     //   uuid: "5f0d4d62-e082-4cdf-a143-26258de59c47",
     //   expiration: 1461649282,
     //   hmac: "fd89637821afca1787dfe458be29bc87f0366122"
@@ -93,17 +88,12 @@ presign(presign_url, token)
  ```
  * `onProgress` - optional, `onProgress` function.
 
-On success, this request will return an array.
-
-The first value of the array will be the response from the attache server:
+On success, this request will return:
 
 * `path` - a unique path for the uploaded file
 * `content_type`
 * `geometry`
 * `bytes`
-
-The 2nd value of the array is the URL the file was uploaded to (the same returned from the presign response).  
-Useful for building paths for thumbnails, original files, etc.
 
 ```js
 
@@ -117,15 +107,12 @@ presign(presign_url)
     return upload(presignResponse, fileObject, customProgressHandler)
   })
   .then((uploadResponse) => {
-    // [
-    //   {
-    //     path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
-    //     content_type: "image/jpeg",
-    //     geometry: "300x300",
-    //     bytes: 19804
-    //   },
-    //   "http://path_to_your_attache_serve/upload"
-    // ]
+    // {
+    //   path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
+    //   content_type: "image/jpeg",
+    //   geometry: "300x300",
+    //   bytes: 19804
+    // }
   })
 ```
 #### getXHRRequests()

--- a/README.md
+++ b/README.md
@@ -25,14 +25,21 @@ presign(presign_url)
   })
   .then((uploadResponse) => {
 
-    // Do something with the uploadResponse
-    // uploadResponse:
-    // {
-    //   path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
-    //   content_type: "image/jpeg",
-    //   geometry: "300x300",
-    //   bytes: 19804
-    // }
+    // Do something with the 'uploadResponse' array.
+    //
+    // uploadResponse[0] = the attache server response
+    // uploadResponse[1] = the url the file was uploaded to.
+    //
+    // [
+    //   {
+    //     path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
+    //     content_type: "image/jpeg",
+    //     geometry: "300x300",
+    //     bytes: 19804
+    //   },
+    //   "http://path_to_your_attache_serve/upload"
+    // ]
+
   })
   .catch((err) => {
     // Handle error
@@ -86,12 +93,17 @@ presign(presign_url, token)
  ```
  * `onProgress` - optional, `onProgress` function.
 
-On success, this request will return:
+On success, this request will return an array.
+
+The first value of the array will be the response from the attache server:
 
 * `path` - a unique path for the uploaded file
 * `content_type`
 * `geometry`
 * `bytes`
+
+The 2nd value of the array is the URL the file was uploaded to (the same returned from the presign response).  
+Useful for building paths for thumbnails, original files, etc.
 
 ```js
 
@@ -105,12 +117,15 @@ presign(presign_url)
     return upload(presignResponse, fileObject, customProgressHandler)
   })
   .then((uploadResponse) => {
-    // {
-    //   path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
-    //   content_type: "image/jpeg",
-    //   geometry: "300x300",
-    //   bytes: 19804
-    // }
+    // [
+    //   {
+    //     path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
+    //     content_type: "image/jpeg",
+    //     geometry: "300x300",
+    //     bytes: 19804
+    //   },
+    //   "http://path_to_your_attache_serve/upload"
+    // ]
   })
 ```
 #### getXHRRequests()

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,9 +91,7 @@ function customError(name, error) {
 
 /**
  * responseStatus
- * take a response and check if it's an array or not.
- * 'uploadRequest()' returns an array [response, url]
- * check the response `status` property
+ * take a response and check the response `status` property
  * if between 200-300 return the response object
  * else throw a custom error
  * @param  {Object} res
@@ -101,35 +99,24 @@ function customError(name, error) {
  */
 
 function responseStatus(res) {
-
-  var response = Array.isArray(res) ? res[0] : res;
-
-  if (response.status >= 200 && response.status < 300) {
+  if (res.status >= 200 && res.status < 300) {
     return res;
   } else {
-    var error = new Error(response.statusText);
-    error.response = response;
+    var error = new Error(res.statusText);
+    error.response = res;
     throw customError('responseStatus', error);
   }
 }
 
 /**
  * parseJSON
- * Take a response object.
- * Check if it's an array.
- * 'uploadRequest()' returns an array [response, url]
- * and return the parsed res.text
+ * Take a response object and return the parsed res.text
  * @param  {String} response
  * @return {Object}
  */
 
 function parseJSON(res) {
-  if (Array.isArray(res)) {
-    res[0] = JSON.parse(res[0].text);
-    return res;
-  } else {
-    return JSON.parse(res.text);
-  }
+  return JSON.parse(res.text);
 }
 
 /**
@@ -178,8 +165,7 @@ function uploadRequest(res, fileObject, showProgress) {
       // throw a custom error message
       if (err) return reject(customError('uploadRequest', err));
 
-      // return and array with the response and the URL is was uploaded to
-      resolve([res, url]);
+      resolve(res);
     });
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.setXHRRequests = exports.getXHRRequests = exports.abortXHRRequest = exports.customError = exports.upload = exports.presign = undefined;
+exports.setXHRRequests = exports.getXHRRequests = exports.abortXHRRequest = exports.customError = exports.upload = exports.presign = exports.parseJSON = exports.responseStatus = undefined;
 
 var _superagent = require('superagent');
 
@@ -91,7 +91,9 @@ function customError(name, error) {
 
 /**
  * responseStatus
- * take a response and check it's `status` property
+ * take a response and check if it's an array or not.
+ * 'uploadRequest()' returns an array [response, url]
+ * check the response `status` property
  * if between 200-300 return the response object
  * else throw a custom error
  * @param  {Object} res
@@ -99,24 +101,35 @@ function customError(name, error) {
  */
 
 function responseStatus(res) {
-  if (res.status >= 200 && res.status < 300) {
+
+  var response = Array.isArray(res) ? res[0] : res;
+
+  if (response.status >= 200 && response.status < 300) {
     return res;
   } else {
-    var error = new Error(res.statusText);
-    error.response = res;
+    var error = new Error(response.statusText);
+    error.response = response;
     throw customError('responseStatus', error);
   }
 }
 
 /**
  * parseJSON
- * Take a response object and return it parsed
+ * Take a response object.
+ * Check if it's an array.
+ * 'uploadRequest()' returns an array [response, url]
+ * and return the parsed res.text
  * @param  {String} response
  * @return {Object}
  */
 
-function parseJSON(res, url) {
-  return JSON.parse(res.text);
+function parseJSON(res) {
+  if (Array.isArray(res)) {
+    res[0] = JSON.parse(res[0].text);
+    return res;
+  } else {
+    return JSON.parse(res.text);
+  }
 }
 
 /**
@@ -151,10 +164,10 @@ function uploadRequest(res, fileObject, showProgress) {
   var file = fileObject.file;
   var uid = fileObject.uid;
 
-  var uploadURL = buildUploadURL(url, uuid, expiration, hmac, file.name);
+  var upload_url = buildUploadURL(url, uuid, expiration, hmac, file.name);
 
   return new Promise(function (resolve, reject) {
-    reqs[uid] = _superagent2.default.put(uploadURL).send(file).set({
+    reqs[uid] = _superagent2.default.put(upload_url).send(file).set({
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     }).on('progress', function (e) {
@@ -165,12 +178,8 @@ function uploadRequest(res, fileObject, showProgress) {
       // throw a custom error message
       if (err) return reject(customError('uploadRequest', err));
 
-      // append the `uploadURL` to the response
-      var response = Object.assign({}, res);
-      var data = JSON.parse(res.text);
-      data.uploadURL = url;
-      response.text = JSON.stringify(data);
-      resolve(response);
+      // return and array with the response and the URL is was uploaded to
+      resolve([res, url]);
     });
   });
 }
@@ -243,6 +252,8 @@ function presign(presignUrl, token) {
   });
 }
 
+exports.responseStatus = responseStatus;
+exports.parseJSON = parseJSON;
 exports.presign = presign;
 exports.upload = upload;
 exports.customError = customError;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attache-upload",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Upload files to your attache server.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "attache-upload",
-  "version": "3.0.0",
+  "version": "2.1.0",
   "description": "Upload files to your attache server.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -78,9 +78,7 @@ function customError (name, error) {
 
 /**
  * responseStatus
- * take a response and check if it's an array or not.
- * 'uploadRequest()' returns an array [response, url]
- * check the response `status` property
+ * take a response and check the response `status` property
  * if between 200-300 return the response object
  * else throw a custom error
  * @param  {Object} res
@@ -88,37 +86,24 @@ function customError (name, error) {
  */
 
 function responseStatus (res) {
-
-  let response = Array.isArray(res)
-    ? res[0]
-    : res
-
-  if (response.status >= 200 && response.status < 300) {
+  if (res.status >= 200 && res.status < 300) {
     return res
   } else {
-    let error = new Error(response.statusText)
-    error.response = response
+    let error = new Error(res.statusText)
+    error.response = res
     throw customError ('responseStatus', error)
   }
 }
 
 /**
  * parseJSON
- * Take a response object.
- * Check if it's an array.
- * 'uploadRequest()' returns an array [response, url]
- * and return the parsed res.text
+ * Take a response object and return the parsed res.text
  * @param  {String} response
  * @return {Object}
  */
 
 function parseJSON (res) {
-  if (Array.isArray(res)) {
-    res[0] = JSON.parse(res[0].text)
-    return res
-  } else {
-    return JSON.parse(res.text)
-  }
+  return JSON.parse(res.text)
 }
 
 /**
@@ -171,8 +156,7 @@ function uploadRequest (res, fileObject, showProgress) {
         // throw a custom error message
         if (err) return reject(customError('uploadRequest', err))
 
-        // return and array with the response and the URL is was uploaded to
-        resolve([res, url])
+        resolve(res)
       })
   })
 }

--- a/test.js
+++ b/test.js
@@ -220,40 +220,21 @@ test('Abort Requests:', (t) => {
  * responseStatus
  */
 
-test('responseStatus:', (nest) => {
-  nest.test('...receive an object', (t) => {
-    const response = {status: 200}
-    const expected = response
-    const actual = responseStatus(response)
-    t.ok(isEqual(actual, expected), 'match')
-    t.end()
-  })
-
-  nest.test('...receive an array', (t) => {
-    const response = [{status: 200}, 'string']
-    const expected = response
-    const actual = responseStatus(response)
-    t.ok(isEqual(actual, expected), 'match')
-    t.end()
-  })
+test('responseStatus:', (t) => {
+  const response = {status: 200}
+  const expected = response
+  const actual = responseStatus(response)
+  t.ok(isEqual(actual, expected), 'match')
+  t.end()
 })
 
 /**
  * parseJSON
  */
 
-test('parseJSON:', (nest) => {
-  nest.test('...receive an object', (t) => {
-    const expected = {foo: 'bar'}
-    const actual = {text: '{"foo": "bar"}'}
-    t.ok(isEqual(parseJSON(actual), expected), 'match')
-    t.end()
-  })
-
-  nest.test('...receive an array', (t) => {
-    const expected = [{foo: 'bar'}, 'string']
-    const actual = [{text: '{"foo": "bar"}'}, 'string']
-    t.ok(isEqual(parseJSON(actual), expected), 'match')
-    t.end()
-  })
+test('parseJSON:', (t) => {
+  const expected = {foo: 'bar'}
+  const actual = {text: '{"foo": "bar"}'}
+  t.ok(isEqual(parseJSON(actual), expected), 'match')
+  t.end()
 })

--- a/test.js
+++ b/test.js
@@ -1,7 +1,17 @@
 
 import test from 'blue-tape'
-import { upload, presign, customError, getXHRRequests, setXHRRequests, abortXHRRequest } from './src'
 import isEqual from 'lodash.isequal'
+
+import {
+  responseStatus,
+  parseJSON,
+  upload,
+  presign,
+  customError,
+  getXHRRequests,
+  setXHRRequests,
+  abortXHRRequest
+} from './src'
 
 const token = ''
 const url = 'www.foo.com'
@@ -204,4 +214,46 @@ test('Abort Requests:', (t) => {
 
   t.ok(isEqual(updated, expected), 'match')
   t.end()
+})
+
+/**
+ * responseStatus
+ */
+
+test('responseStatus:', (nest) => {
+  nest.test('...receive an object', (t) => {
+    const response = {status: 200}
+    const expected = response
+    const actual = responseStatus(response)
+    t.ok(isEqual(actual, expected), 'match')
+    t.end()
+  })
+
+  nest.test('...receive an array', (t) => {
+    const response = [{status: 200}, 'string']
+    const expected = response
+    const actual = responseStatus(response)
+    t.ok(isEqual(actual, expected), 'match')
+    t.end()
+  })
+})
+
+/**
+ * parseJSON
+ */
+
+test('parseJSON:', (nest) => {
+  nest.test('...receive an object', (t) => {
+    const expected = {foo: 'bar'}
+    const actual = {text: '{"foo": "bar"}'}
+    t.ok(isEqual(parseJSON(actual), expected), 'match')
+    t.end()
+  })
+
+  nest.test('...receive an array', (t) => {
+    const expected = [{foo: 'bar'}, 'string']
+    const actual = [{text: '{"foo": "bar"}'}, 'string']
+    t.ok(isEqual(parseJSON(actual), expected), 'match')
+    t.end()
+  })
 })


### PR DESCRIPTION
@makenosound @timriley.

Hello.
This PR undoes the mutation of the attache server response.

The reason for this mutation in the first place was to easily send back the url the file was uploaded to in the response. We could then use this URL to build paths for anchors or thumbnails.

```
{
  path: "65/77/08/5a/c2/f7/b0/f1/f3/33/53/7c/bf/5d/62/f4/swimming.jpg",
  content_type: "image/jpeg",
  geometry: "300x300",
  bytes: 19804,
  uploadURL: "http://path_to_your_attache_server/upload"  // << mutation
}
```

The reason why the response was mutated is because a `Promise` can only resolve 1 value.

```
return new Promise((resolve, reject) => {
  resolve("hello", true, 5) // it would resolve "hello"
})
```

This PR now returns an array when a file has been successfully uploaded.
The array consists of the parsed attache response and the URL.

```
resolve([res, url])
```

So now the usage of this module looks like:

```
presign(presign_url)
  .then((presignResponse) => {
    return upload(presignResponse, fileObject)
  })
  .then((uploadResponse) => {

    // Do something with the 'uploadResponse' array.
    //
    // uploadResponse[0] = the attache server response
    // uploadResponse[1] = the url the file was uploaded to.
    //
    // [
    //   {
    //     path: "54/4d/15/14/b4/09/29/01/36/42/2f/e2/3f/f0/42/15/some_file.jpg",
    //     content_type: "image/jpeg",
    //     geometry: "300x300",
    //     bytes: 19804
    //   },
    //   "http://path_to_your_attache_server/upload"
    // ]

  })
  .catch((err) => {
    // Handle error
  })
```

And we can choose to use the supplied URL or not in the UI.
